### PR TITLE
Add stubbyid dependency for testing.

### DIFF
--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -151,6 +151,7 @@
 
 <script src="js/lib/require.js"></script>
 <script>
+  window.ENV = 'production';
   require(['js/config'], function () {
     require(['app/main'])
   });

--- a/resources/public/js/config.js
+++ b/resources/public/js/config.js
@@ -26,7 +26,13 @@ requirejs.config({
     "ramda": "//cdnjs.cloudflare.com/ajax/libs/ramda/0.10.0/ramda.min",
     "jquery.validate": "//cdn.jsdelivr.net/jquery.validation/1.14.0/jquery.validate.min",
     "jquery.migrate": "//code.jquery.com/jquery-migrate-1.2.1.min",
-    "persona": "//login.persona.org/include"
+    "persona": (function(){
+      if (window.ENV === 'production') {
+        return "//login.persona.org/include";
+      } else {
+        return "//rawgit.com/toolness/stubbyid/gh-pages/stubbyid"
+      }
+    }())
   },
   "shim": {
     "bootstrap": {

--- a/resources/public/js/config.js
+++ b/resources/public/js/config.js
@@ -27,10 +27,10 @@ requirejs.config({
     "jquery.validate": "//cdn.jsdelivr.net/jquery.validation/1.14.0/jquery.validate.min",
     "jquery.migrate": "//code.jquery.com/jquery-migrate-1.2.1.min",
     "persona": (function(){
-      if (window.ENV === 'production') {
-        return "//login.persona.org/include";
+      if (window.ENV === 'dev') {
+        return "//rawgit.com/toolness/stubbyid/gh-pages/stubbyid";
       } else {
-        return "//rawgit.com/toolness/stubbyid/gh-pages/stubbyid"
+        return "//login.persona.org/include";
       }
     }())
   },

--- a/src/crispy_tatertot/handler.clj
+++ b/src/crispy_tatertot/handler.clj
@@ -85,14 +85,14 @@
           :return String
           :form-params [assertion :- String]
           :summary "Establish a session"
-               (if (= environment "production")
+               (if (= environment "dev")
+                 (sign-user-in session assertion)
+
                  (let [{:keys [email] :as response}
                        (persona/verify-assertion assertion audience)]
                    (if (persona/valid? response)
                      (sign-user-in session email)
-                     (unauthorized)))
-
-                 (sign-user-in session assertion)))
+                     (unauthorized)))))
 
         (DELETE* "/" []
           :summary "Destroy the current session, if it exists"

--- a/src/crispy_tatertot/handler.clj
+++ b/src/crispy_tatertot/handler.clj
@@ -56,8 +56,7 @@
 (defn sign-user-in
   [session email]
   (merge {:session (assoc session ::identity {:emailAddress email})}
-         (ok email))
-  )
+         (ok email)))
 
 (defapi app
   (swagger-ui "/swagger-ui"


### PR DESCRIPTION
Motivations:
1) I don't have to keep logging into persona.
2) I can create arbitrary users. This will come in handy
    when testing the chat interaction with multiple users.

How to use:
1) Set the `CRISPY_ENV` environment variable to something other than `production`
2) Modify the JS in index.html and change window.ENV.

Future work:
Figure out how to get RequireJS to automatically load the stubbyid code in
non-production environments. Changing the JS in index.html is annoying,
and we might accidentally commit it as some point.

Some possible approaches:
1) Set it via some server side templating. We don't need server side templating
   for anything else yet, so I'd rather avoid introducing that just for testing.
2) Load a different resource dynamically based on the server env.
3) Some better idea?